### PR TITLE
Add Pipeline#wrap to supersede implicit non-callable wrapping (closes #2)

### DIFF
--- a/lib/piperator/pipeline.rb
+++ b/lib/piperator/pipeline.rb
@@ -41,6 +41,7 @@ module Piperator
 
     def initialize(pipes = [])
       @pipes = pipes
+      freeze
     end
 
     # Compute the pipeline and return a lazy enumerable with all the pipes.

--- a/lib/piperator/pipeline.rb
+++ b/lib/piperator/pipeline.rb
@@ -11,11 +11,23 @@ module Piperator
     # @param callable An object responding to call(enumerable)
     # @return [Pipeline] A pipeline containing only the callable
     def self.pipe(callable)
-      if callable.respond_to?(:call)
-        Pipeline.new([callable])
-      else
-        Pipeline.new([->(_) { callable }])
-      end
+      Pipeline.new([callable])
+    end
+
+    # Build a new pipeline from a from a non-callable, i.e. string, array, etc.
+    # This method will wrap the value in a proc, thus making it callable.
+    #
+    #   Piperator::Pipeline.wrap([1, 2, 3]).pipe(add_one)
+    #   # => [2, 3, 4]
+    #
+    #   # Wrap is syntactic sugar for wrapping a value in a proc
+    #   Piperator::Pipeline.pipe(->(_) { [1, 2, 3] }).pipe(add_one)
+    #   # => [2, 3, 4]
+    #
+    # @param callable A raw value which will be passed through the pipeline
+    # @return [Pipeline] A pipeline containing only the callable
+    def self.wrap(value)
+      Pipeline.new([->(_) { value }])
     end
 
     # Returns enumerable given as an argument without modifications. Usable when
@@ -52,6 +64,15 @@ module Piperator
     # @return [Pipeline] A new pipeline instance
     def pipe(other)
       Pipeline.new(@pipes + [other])
+    end
+
+    # Add a new value to the pipeline
+    #
+    # @param other A value which is wrapped into a pipe, then appended to the
+    # pipeline.
+    # @return [Pipeline] A new pipeline instance
+    def wrap(other)
+      Pipeline.new(@pipes + [->(_) { other }])
     end
   end
 end

--- a/spec/piperator/pipeline_spec.rb
+++ b/spec/piperator/pipeline_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe Piperator::Pipeline do
         .to eq([4, 9, 16])
     end
 
+    it 'can compose values with using Pipeline#wrap' do
+      pipeline = Piperator::Pipeline.wrap([1, 2, 3]).pipe(square)
+
+      expect(pipeline.call.to_a).to eq([1, 4, 9])
+    end
+
     it 'can start composition from empty Pipeline class' do
       expect(Piperator::Pipeline.pipe(add1).call([3]).to_a).to eq([4])
     end
@@ -45,7 +51,7 @@ RSpec.describe Piperator::Pipeline do
     end
 
     it 'can start pipeline from an enumerable' do
-      pipeline = Piperator::Pipeline.pipe([1, 2, 3]).pipe(add1)
+      pipeline = Piperator::Pipeline.wrap([1, 2, 3]).pipe(add1)
       expect(pipeline.to_a).to eq([2, 3, 4])
     end
 


### PR DESCRIPTION
Previously, any non-callable value passed to `Pipeline#pipe` was implicitly
wrapped in a lambda. There are a few reasons this behavior is not ideal:

1. It can lead to confusing scenarios when typos occurs (fat-thumbing a method
   as `calll` and wondering why everything is mysteriously broken)

2. Encourages use of magic behavior. If someone uses a non-callable as an
   argument, a read will have to ask themselves some questions:

   a) Is the argument a callable? This involves a potentially timely source-dive.

   b) If it's not a callable, I will likely have to source dive to see that
      `Piperator::Pipeline` automatically wraps a non-callable. It's not obvious
      that Pipeline should do this for the user. Principle of least surprise,
      yada-yada.

3. `respond_to?` adds a small percentage overhead which many people will pay
   for, and a small amount of people will benefit from.

On top of removing implicit wrapping, this commit adds `Pipeline#wrap`, which
is syntactic sugar for wrapping a value in a lambda. This way, we can favor
explicitness, but still provide an easy-to-use, non-ceremonious API.

So this example from the old API:

```ruby
   Piperator::Pipeline.pipe([1, 2, 3]).pipe(add1)
   # => [2, 3, 4]
```

Would now become:

```ruby
   Piperator::Pipeline.wrap([1, 2, 3]).pipe(add1)
   # => [2, 3, 4]
```