### PR TITLE
DSL for building pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Piperator.
 # => 18
 ```
 
+The same could also be achieved using DSL instead of method chaining:
+
+```ruby
+Piperator.build do
+  pipe(->(values) { values.lazy.map { |i| i * 3 } })
+  pipe(->(values) { values.sum })
+end.call([1, 2, 3])
+```
+
 If desired, the input enumerable can also be given as the first element of the pipeline using `Piperator.wrap`.
 
 ```ruby

--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -5,9 +5,22 @@ require 'piperator/builder'
 
 # Top-level shortcuts
 module Piperator
-  # Build a new pipeline using DSL
+  # Build a new pipeline using DSL. This enables easy control of the pipeline
+  # stucture.
   #
-  # @see Piperator::Pipeline
+  #   Piperator.build do
+  #     wrap [1, 2, 3]
+  #     pipe(-> (enumerable) { enumerable.map { |i| i + 1 } })
+  #   end
+  #   # => Pipeline that returns [2, 3, 4] called
+  #
+  #   # Alternatively, the Builder is also given as argument to the block
+  #   Piperator.build do |p|
+  #     p.wrap [1, 2, 3]
+  #     p.pipe(-> (enumerable) { enumerable.map { |i| i + 1 } })
+  #   end
+  #   # This is similar, but allows access to instance variables.
+  #
   # @return [Pipeline] Pipeline containing defined steps
   def self.build(&block)
     return Pipeline.new unless block_given?
@@ -24,7 +37,7 @@ module Piperator
   # Build a new pipeline from a callable or an enumerable object
   #
   # @see Piperator::Pipeline.pipe
-  # @param callable An object responding to call(enumerable)
+  # @param enumerable An object responding to call(enumerable)
   # @return [Pipeline] A pipeline containing only the callable
   def self.pipe(enumerable)
     Pipeline.pipe(enumerable)

--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -1,9 +1,20 @@
 require 'piperator/version'
 require 'piperator/pipeline'
 require 'piperator/io'
+require 'piperator/builder'
 
 # Top-level shortcuts
 module Piperator
+  # Build a new pipeline using DSL
+  #
+  # @see Piperator::Pipeline
+  # @return [Pipeline] Pipeline containing defined steps
+  def self.pipeline(&block)
+    Builder.new.tap do |builder|
+      builder.instance_eval(&block)
+    end.to_pipeline
+  end
+
   # Build a new pipeline from a callable or an enumerable object
   #
   # @see Piperator::Pipeline.pipe

--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -9,7 +9,7 @@ module Piperator
   #
   # @see Piperator::Pipeline
   # @return [Pipeline] Pipeline containing defined steps
-  def self.pipeline(&block)
+  def self.build(&block)
     Builder.new(block.binding).tap do |builder|
       if block.arity.positive?
         yield builder

--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -10,7 +10,7 @@ module Piperator
   # @see Piperator::Pipeline
   # @return [Pipeline] Pipeline containing defined steps
   def self.pipeline(&block)
-    Builder.new.tap do |builder|
+    Builder.new(block.binding).tap do |builder|
       builder.instance_eval(&block)
     end.to_pipeline
   end

--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -10,7 +10,9 @@ module Piperator
   # @see Piperator::Pipeline
   # @return [Pipeline] Pipeline containing defined steps
   def self.build(&block)
-    Builder.new(block.binding).tap do |builder|
+    return Pipeline.new unless block_given?
+
+    Builder.new(block&.binding).tap do |builder|
       if block.arity.positive?
         yield builder
       else

--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -11,7 +11,11 @@ module Piperator
   # @return [Pipeline] Pipeline containing defined steps
   def self.pipeline(&block)
     Builder.new(block.binding).tap do |builder|
-      builder.instance_eval(&block)
+      if block.arity.positive?
+        yield builder
+      else
+        builder.instance_eval(&block)
+      end
     end.to_pipeline
   end
 

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -1,0 +1,17 @@
+module Piperator
+  class Builder
+    def initialize(pipeline = Pipeline.new)
+      @pipeline = pipeline
+    end
+
+    def to_pipeline
+      @pipeline
+    end
+
+    %i[pipe wrap].each do |method|
+      define_method method do |value|
+        @pipeline = @pipeline.send(method, value)
+      end
+    end
+  end
+end

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -1,11 +1,24 @@
 module Piperator
   class Builder
-    def initialize(pipeline = Pipeline.new)
+    def initialize(saved_binding, pipeline = Pipeline.new)
       @pipeline = pipeline
+      @saved_binding = saved_binding
     end
 
     def to_pipeline
       @pipeline
+    end
+
+    def method_missing(method_name, *arguments, &block)
+      if @saved_binding.receiver.respond_to?(method_name)
+        @saved_binding.receiver.send(method_name, *arguments, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(meth, include_private = false)
+      @saved_binding.receiver.respond_to?(method_name, include_private) || super
     end
 
     %i[pipe wrap].each do |method|

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -17,7 +17,7 @@ module Piperator
       end
     end
 
-    def respond_to_missing?(meth, include_private = false)
+    def respond_to_missing?(method_name, include_private = false)
       @saved_binding.receiver.respond_to?(method_name, include_private) || super
     end
 

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -1,13 +1,42 @@
 module Piperator
+  # Builder is used to provide DSL-based Pipeline building. Using Builder,
+  # Pipelines can be built without pipe chaining, which might be easier if
+  # some steps need to be included only on specific conditions.
+  #
+  # @see Piperator.build
   class Builder
+    # Expose a chained method in Pipeline in DSL
+    #
+    # @param method_name Name of method in Pipeline
+    # @see Pipeline
+    #
+    # @!macro [attach] dsl_method
+    #   @method $1
+    #   Call Pipeline#$1 given arguments and use the return value as builder state.
+    #
+    #   @see Pipeline.$1
+    def self.dsl_method(method_name)
+      define_method(method_name) do |*arguments|
+        @pipeline = @pipeline.send(method_name, *arguments)
+      end
+    end
+
+    dsl_method :pipe
+    dsl_method :wrap
+
     def initialize(saved_binding, pipeline = Pipeline.new)
       @pipeline = pipeline
       @saved_binding = saved_binding
     end
 
+    # Return build pipeline
+    #
+    # @return [Pipeline]
     def to_pipeline
       @pipeline
     end
+
+    private
 
     def method_missing(method_name, *arguments, &block)
       if @saved_binding.receiver.respond_to?(method_name, true)
@@ -19,12 +48,6 @@ module Piperator
 
     def respond_to_missing?(method_name, include_private = false)
       @saved_binding.receiver.respond_to?(method_name, include_private) || super
-    end
-
-    %i[pipe wrap].each do |method|
-      define_method method do |value|
-        @pipeline = @pipeline.send(method, value)
-      end
     end
   end
 end

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -10,7 +10,7 @@ module Piperator
     end
 
     def method_missing(method_name, *arguments, &block)
-      if @saved_binding.receiver.respond_to?(method_name)
+      if @saved_binding.receiver.respond_to?(method_name, true)
         @saved_binding.receiver.send(method_name, *arguments, &block)
       else
         super

--- a/lib/piperator/version.rb
+++ b/lib/piperator/version.rb
@@ -1,3 +1,4 @@
 module Piperator
+  # Piperator version
   VERSION = '0.3.0'.freeze
 end

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -13,15 +13,38 @@ RSpec.describe Piperator do
     expect(Piperator.wrap([1]).call.to_a).to eq([1])
   end
 
-  it 'can build a pipeline with block' do
-    def ok?
-      true
+  describe '.pipeline' do
+    it 'can build a pipeline with block' do
+      def ok?
+        true
+      end
+      pipeline = Piperator.pipeline do
+        wrap [4, 5] if ok?
+        pipe(->(input) { input.lazy.map { |i| i + 1 } })
+        pipe(->(input) { input.lazy.map { |i| i * 2 } })
+      end
+      expect(pipeline.call.to_a).to eq([10, 12])
     end
-    pipeline = Piperator.pipeline do
-      wrap [4, 5] if ok?
-      pipe(->(input) { input.lazy.map { |i| i + 1 } })
-      pipe(->(input) { input.lazy.map { |i| i * 2 } })
+
+    it 'can call private methods' do
+      klass = Class.new do
+        def pipeline
+          Piperator.pipeline do
+            wrap [4, 5]
+            pipe plus1
+          end
+        end
+
+        private
+
+        def plus1
+          ->(input) { input.lazy.map { |i| i + 1 } }
+        end
+      end
+
+      expect(klass.new.pipeline.to_a).to eq([5, 6])
     end
-    expect(pipeline.call.to_a).to eq([10, 12])
   end
+
+
 end

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe Piperator do
   it 'has a version number' do
     expect(Piperator::VERSION).not_to be nil
@@ -13,12 +14,12 @@ RSpec.describe Piperator do
     expect(Piperator.wrap([1]).call.to_a).to eq([1])
   end
 
-  describe '.pipeline' do
+  describe '.build' do
     it 'can build a pipeline with block' do
       def ok?
         true
       end
-      pipeline = Piperator.pipeline do
+      pipeline = Piperator.build do
         wrap [4, 5] if ok?
         pipe(->(input) { input.lazy.map { |i| i + 1 } })
         pipe(->(input) { input.lazy.map { |i| i * 2 } })
@@ -29,7 +30,7 @@ RSpec.describe Piperator do
     it 'can call private methods' do
       klass = Class.new do
         def pipeline
-          Piperator.pipeline do
+          Piperator.build do
             wrap [4, 5]
             pipe plus1
           end
@@ -48,12 +49,10 @@ RSpec.describe Piperator do
     it 'gives builder as argument' do
       @ok = -> { true }
 
-      expect(Piperator.pipeline do |pipeline|
+      expect(Piperator.build do |pipeline|
         pipeline.wrap [4, 5] if @ok
         pipeline.pipe(->(input) { input.lazy.map { |i| i + 1 } })
       end.to_a).to eq([5, 6])
     end
   end
-
-
 end

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe Piperator do
   it 'can start wrap directly from Piperator' do
     expect(Piperator.wrap([1]).call.to_a).to eq([1])
   end
+
+  it 'can build a pipeline with block' do
+    pipeline = Piperator.pipeline do
+      wrap [4, 5]
+      pipe(->(input) { input.lazy.map { |i| i + 1 } })
+      pipe(->(input) { input.lazy.map { |i| i * 2 } })
+    end
+    expect(pipeline.call.to_a).to eq([10, 12])
+  end
 end

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -14,8 +14,11 @@ RSpec.describe Piperator do
   end
 
   it 'can build a pipeline with block' do
+    def ok?
+      true
+    end
     pipeline = Piperator.pipeline do
-      wrap [4, 5]
+      wrap [4, 5] if ok?
       pipe(->(input) { input.lazy.map { |i| i + 1 } })
       pipe(->(input) { input.lazy.map { |i| i * 2 } })
     end

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe Piperator do
 
       expect(klass.new.pipeline.to_a).to eq([5, 6])
     end
+
+    it 'gives builder as argument' do
+      @ok = -> { true }
+
+      expect(Piperator.pipeline do |pipeline|
+        pipeline.wrap [4, 5] if @ok
+        pipeline.pipe(->(input) { input.lazy.map { |i| i + 1 } })
+      end.to_a).to eq([5, 6])
+    end
   end
 
 

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Piperator do
   end
 
   describe '.build' do
+    it 'returns a new Pipeline' do
+      expect(Piperator.build).to be_a(Piperator::Pipeline)
+    end
+
     it 'can build a pipeline with block' do
       def ok?
         true


### PR DESCRIPTION
Add DSL for defining pipelines. This allows easier controlling of especially conditional steps without adding a lot of new methods or options. Closes #6.

TODO:

- [x] documentation
- [x] unit tests for DSL builder