### PR TITLE
This is the issue with this approach however..

### DIFF
--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe Piperator do
     end
     expect(pipeline.call.to_a).to eq([10, 12])
   end
+
+  it 'can build a pipeline with block referencing methods/variables outside of the block scope' do
+    def should_do_step?
+      true
+    end
+    pipeline = Piperator.pipeline do
+      wrap [4, 5]
+      pipe(->(input) { input.lazy.map { |i| i + 1 } }) if should_do_step?
+      pipe(->(input) { input.lazy.map { |i| i * 2 } })
+    end
+    expect(pipeline.call.to_a).to eq([10, 12])
+  end
 end


### PR DESCRIPTION
This test is going to fail now with the `instance_eval` approach.. I'm thinking that maybe if we could actually instead of instance evalling include the build methods to the yield context or something.. haven't really tested this idea though, I would imagine it to be possible.

Demonstrates the problem with approach in https://github.com/lautis/piperator/pull/7