### PR TITLE
Rename @io to @buffer, and address #pos bug

### DIFF
--- a/lib/piperator/io.rb
+++ b/lib/piperator/io.rb
@@ -10,9 +10,9 @@ module Piperator
     def initialize(enumerator, flush_threshold: FLUSH_THRESHOLD)
       @enumerator = enumerator
       @flush_threshold = flush_threshold
-      @io = StringIO.new
+      @buffer = StringIO.new
       @buffer_start_pos = 0
-      @io_read_pos = 0
+      @buffer_read_pos = 0
       @eof = false
     end
 
@@ -21,7 +21,7 @@ module Piperator
     # Return the first bytes of the buffer without marking the buffer as read.
     def peek(bytes)
       while @eof == false && readable_bytes < (bytes || 1)
-        @io.write(@enumerator.next)
+        @buffer.write(@enumerator.next)
       end
       peek_buffer(bytes)
     rescue StopIteration
@@ -38,22 +38,22 @@ module Piperator
     def gets(separator = $INPUT_RECORD_SEPARATOR, _limit = nil)
       while !@eof && !contains_line?(separator)
         begin
-          @io.write(@enumerator.next)
+          @buffer.write(@enumerator.next)
         rescue StopIteration
           @eof = true
           nil
         end
       end
-      read_with { @io.gets(separator) }
+      read_with { @buffer.gets(separator) }
     end
 
     # Flush internal buffer until the last unread byte
     def flush
-      if @io.pos == @io_read_pos
+      if @buffer.pos == @buffer_read_pos
         initialize_buffer
       else
-        @io.pos = @io_read_pos
-        initialize_buffer(@io.read)
+        @buffer.pos = @buffer_read_pos
+        initialize_buffer(@buffer.read)
       end
     end
 
@@ -63,55 +63,55 @@ module Piperator
     # @return String
     def read(length = nil)
       return @enumerator.next if length.nil? && readable_bytes.zero?
-      @io.write(@enumerator.next) while !@eof && readable_bytes < (length || 1)
-      read_with { @io.read(length) }
+      @buffer.write(@enumerator.next) while !@eof && readable_bytes < (length || 1)
+      read_with { @buffer.read(length) }
     rescue StopIteration
       @eof = true
-      read_with { @io.read(length) } if readable_bytes > 0
+      read_with { @buffer.read(length) } if readable_bytes > 0
     end
 
     # Current buffer size - including non-freed read content
     #
     # @return [Integer] number of bytes stored in buffer
     def used
-      @io.size
+      @buffer.size
     end
 
     private
 
     def readable_bytes
-      @io.pos - @io_read_pos
+      @buffer.pos - @buffer_read_pos
     end
 
     def read_with
-      pos = @io.pos
-      @io.pos = @io_read_pos
+      pos = @buffer.pos
+      @buffer.pos = @buffer_read_pos
 
       yield.tap do |data|
-        @io_read_pos += data.bytesize if data
-        @io.pos = pos
+        @buffer_read_pos += data.bytesize if data
+        @buffer.pos = pos
         flush if flush?
       end
     end
 
     def peek_buffer(bytes)
-      @io.string.byteslice(@io_read_pos...@io_read_pos + bytes)
+      @buffer.string.byteslice(@buffer_read_pos...@buffer_read_pos + bytes)
     end
 
     def flush?
-      @io.pos == @io_read_pos || @io.pos > @flush_threshold
+      @buffer.pos == @buffer_read_pos || @buffer.pos > @flush_threshold
     end
 
     def initialize_buffer(data = nil)
-      @io_read_pos = 0
-      @buffer_start_pos += @io.pos if @io
-      @io = StringIO.new
-      @io.write(data) if data
+      @buffer_read_pos = 0
+      @buffer_start_pos += @buffer.pos if @buffer
+      @buffer = StringIO.new
+      @buffer.write(data) if data
     end
 
     def contains_line?(separator = $INPUT_RECORD_SEPARATOR)
       return true if @eof
-      @io.string.byteslice(@io_read_pos..-1).include?(separator)
+      @buffer.string.byteslice(@buffer_read_pos..-1).include?(separator)
     rescue ArgumentError # Invalid UTF-8
       false
     end

--- a/spec/piperator/io_spec.rb
+++ b/spec/piperator/io_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Piperator::IO do
     end
   end
 
+  describe '#pos' do
+    subject { Piperator::IO.new(%w[123 456].each, flush_threshold: 4) }
+
+    it 'is correctly set when using the default #read' do
+      expect { subject.read }.to change(subject, :pos).to(3)
+    end
+
+    it 'is correctly set when performing a partial #read' do
+      expect { subject.read(4) }.to change(subject, :pos).to(4)
+    end
+  end
+
   describe '#gets' do
     subject { Piperator::IO.new(["foo\n", "bar\n"].each) }
 


### PR DESCRIPTION
First off, thanks for creating `Piperator`! We have been happily using `Piperator::IO` in order to send files in chunks over HTTP. :-)

The last couple of weeks we are using it to send files to a new service, which keeps track of the bytes sent.
In order for that to work we had to add a `#pos` attribute to the object able to indicate how many bytes have been #read from the wrapped enumerator. For this, we repurposed seemingly unused `@buffer_start_pos`.

The second commit fixes a bug: `@buffer.pos` is the write position of the internal `StringIO`, but it should actually be using `@buffer_read_pos` when passing a remainder (for reading later) to initialise a new buffer with

25fa74fdd0cddce193f145ab7b3a509d71f2dd3e