### PR TITLE
Add Pipeline#lazy for constructing pipes lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ Piperator.
 # => 18
 ```
 
+Have reasons to defer constructing a pipe? Evaluate it lazily:
+
+```ruby
+summing = ->(values) { values.sum }
+Piperator.build
+  pipe(->(values) { values.lazy.map { |i| i * 3 } })
+  lazy do
+    summing
+  end
+end.call([1, 2, 3])
+```
+
 There is, of course, a much more idiomatic alternative in Ruby:
 
 ```ruby

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -16,11 +16,12 @@ module Piperator
     #
     #   @see Pipeline.$1
     def self.dsl_method(method_name)
-      define_method(method_name) do |*arguments|
-        @pipeline = @pipeline.send(method_name, *arguments)
+      define_method(method_name) do |*arguments, &block|
+        @pipeline = @pipeline.send(method_name, *arguments, &block)
       end
     end
 
+    dsl_method :lazy
     dsl_method :pipe
     dsl_method :wrap
 

--- a/lib/piperator/pipeline.rb
+++ b/lib/piperator/pipeline.rb
@@ -6,6 +6,20 @@ module Piperator
   # For streaming purposes, it usually is desirable to have pipes that takes
   # a lazy Enumerator as an argument a return a (modified) lazy Enumerator.
   class Pipeline
+    # Build a new pipeline from a lazily evaluated callable or an enumerable
+    # object.
+    #
+    # @param block A block returning a callable(enumerable)
+    # @return [Pipeline] A pipeline containing only the lazily evaluated
+    # callable.
+    def self.lazy(&block)
+      callable = nil
+      Pipeline.new([lambda do |e|
+        callable ||= block.call
+        callable.call(e)
+      end])
+    end
+
     # Build a new pipeline from a callable or an enumerable object
     #
     # @param callable An object responding to call(enumerable)
@@ -57,6 +71,19 @@ module Piperator
     # @return [Array]
     def to_a(enumerable = [])
       call(enumerable).to_a
+    end
+
+    # Add a new lazily evaluated part to the pipeline.
+    #
+    # @param block A block returning a callable(enumerable) to append in
+    # pipeline.
+    # @return [Pipeline] A new pipeline instance
+    def lazy(&block)
+      callable = nil
+      Pipeline.new(@pipes + [lambda do |e|
+        callable ||= block.call
+        callable.call(e)
+      end])
     end
 
     # Add a new part to the pipeline

--- a/spec/piperator/pipeline_spec.rb
+++ b/spec/piperator/pipeline_spec.rb
@@ -59,4 +59,29 @@ RSpec.describe Piperator::Pipeline do
       expect(Piperator::Pipeline.pipe(add1).pipe(sum).call([1, 2, 3])).to eq(9)
     end
   end
+
+  describe '#lazy' do
+    it 'gets invoked' do
+      counter = 0
+      chain = Piperator::Pipeline.pipe(add1).lazy do
+        counter += 1
+        ->(input) { input.lazy }
+      end
+
+      expect(chain.call([1, 2, 3]).to_a).to eq([2, 3, 4])
+      expect(counter).to eq(1)
+    end
+
+    it 'memoizes its pipe' do
+      counter = 0
+      chain = Piperator::Pipeline.pipe(add1).lazy do
+        counter += 1
+        ->(input) { input.lazy }
+      end
+
+      expect(chain.call([1, 2, 3]).to_a).to eq([2, 3, 4])
+      expect(chain.call([1, 2, 3]).to_a).to eq([2, 3, 4])
+      expect(counter).to eq(1)
+    end
+  end
 end

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -20,15 +20,21 @@ RSpec.describe Piperator do
     end
 
     it 'can build a pipeline with block' do
+      counter = 0
       def ok?
         true
       end
       pipeline = Piperator.build do
         wrap [4, 5] if ok?
         pipe(->(input) { input.lazy.map { |i| i + 1 } })
+        lazy do
+          counter += 1
+          ->(input) { input.lazy }
+        end
         pipe(->(input) { input.lazy.map { |i| i * 2 } })
       end
       expect(pipeline.call.to_a).to eq([10, 12])
+      expect(counter).to eq(1)
     end
 
     it 'can call private methods' do


### PR DESCRIPTION
The PR adds a new builder method for constructing pipelines called `lazy`. This should help to construct pipes in pipelines lazily and reduce boilerplate like

```ruby
  pipe(lambda do |a|
    my_pipe.call(a)
  end)
```

into

```ruby
  lazy do
    my_pipe
  end
```