### PR TITLE
Use docile to simplify dsl setup

### DIFF
--- a/lib/piperator.rb
+++ b/lib/piperator.rb
@@ -2,6 +2,7 @@ require 'piperator/version'
 require 'piperator/pipeline'
 require 'piperator/io'
 require 'piperator/builder'
+require 'docile'
 
 # Top-level shortcuts
 module Piperator
@@ -25,11 +26,11 @@ module Piperator
   def self.build(&block)
     return Pipeline.new unless block_given?
 
-    Builder.new(block&.binding).tap do |builder|
+    Builder.new.tap do |builder|
       if block.arity.positive?
         yield builder
       else
-        builder.instance_eval(&block)
+        Docile.dsl_eval(builder, &block)
       end
     end.to_pipeline
   end

--- a/lib/piperator/builder.rb
+++ b/lib/piperator/builder.rb
@@ -25,9 +25,8 @@ module Piperator
     dsl_method :pipe
     dsl_method :wrap
 
-    def initialize(saved_binding, pipeline = Pipeline.new)
+    def initialize(pipeline = Pipeline.new)
       @pipeline = pipeline
-      @saved_binding = saved_binding
     end
 
     # Return build pipeline
@@ -35,20 +34,6 @@ module Piperator
     # @return [Pipeline]
     def to_pipeline
       @pipeline
-    end
-
-    private
-
-    def method_missing(method_name, *arguments, &block)
-      if @saved_binding.receiver.respond_to?(method_name, true)
-        @saved_binding.receiver.send(method_name, *arguments, &block)
-      else
-        super
-      end
-    end
-
-    def respond_to_missing?(method_name, include_private = false)
-      @saved_binding.receiver.respond_to?(method_name, include_private) || super
     end
   end
 end

--- a/piperator.gemspec
+++ b/piperator.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'docile', '~> 1.3'
+
   spec.add_development_dependency 'bundler', '>= 1.14'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/piperator_spec.rb
+++ b/spec/piperator_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe Piperator do
       def ok?
         true
       end
+      @four = 4
       pipeline = Piperator.build do
-        wrap [4, 5] if ok?
+        wrap [@four, 5] if ok?
         pipe(->(input) { input.lazy.map { |i| i + 1 } })
         lazy do
           counter += 1


### PR DESCRIPTION
Using Docile https://github.com/ms-ati/docile instead of cooking our own DSL building logic would have some benefits:
- Maybe more standard DSL as other libraries also use it.. e.g.  at lest `pena` already has docile as some of its gems dependencies.
- A few less lines for `piperator` to maintain as `Builder` now significantly simplified
- In addition to current things we can do with DSL would also allow referencing instance variables, albeit setting the variables from nested blocks is not possible, so in piperators case e.g. a `@counter` can not really be used

On the other hand it's an extra dependency to a small utility library which so far has had none. I can certainly see the appeal in keeping things that way. Also the instance variable handling has raised some concerns https://github.com/ms-ati/docile/issues/37