### PR TITLE
Add optional buffer argument to Piperator::IO#read.

### DIFF
--- a/lib/piperator/io.rb
+++ b/lib/piperator/io.rb
@@ -62,14 +62,15 @@ module Piperator
     # Reads length bytes from the I/O stream.
     #
     # @param length [Integer] number of bytes to read
+    # @param buffer [String] optional read buffer
     # @return String
-    def read(length = nil)
+    def read(length = nil, buffer = nil)
       return @enumerator.next.tap { |e| @pos += e.bytesize } if length.nil? && readable_bytes.zero?
       @buffer.write(@enumerator.next) while !@eof && readable_bytes < (length || 1)
-      read_with { @buffer.read(length) }
+      read_with { @buffer.read(length, buffer) }
     rescue StopIteration
       @eof = true
-      read_with { @buffer.read(length) } if readable_bytes > 0
+      read_with { @buffer.read(length, buffer) } if readable_bytes > 0
     end
 
     # Current buffer size - including non-freed read content

--- a/spec/piperator/io_spec.rb
+++ b/spec/piperator/io_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Piperator::IO do
     it 'defaults to returning items one by one' do
       expect(subject.read).to eq('foo')
     end
+
+    it 'reads into buffer' do
+      buffer = ''
+      subject.read(2, buffer)
+
+      expect(buffer).to eq('fo')
+    end
   end
 
   describe '#pos' do


### PR DESCRIPTION
- it makes it compatible with `IO::copy_stream`

```ruby
file = File.open('abc', 'w')
pio = Piperator::IO.new(["hello", "world"].each)
IO.copy_stream(pio, file)
file.flush
File.read('abc') #=> helloworld
```